### PR TITLE
网易云音乐歌词显示

### DIFF
--- a/mobile/src/main/java/com/nuomi/MainActivity.java
+++ b/mobile/src/main/java/com/nuomi/MainActivity.java
@@ -96,9 +96,10 @@ public class MainActivity extends AppCompatActivity {
             String pkg = getSharedPreferences("session_pref", MODE_PRIVATE)
                     .getString("last_pkg", null);
             boolean isQQ = "com.tencent.qqmusic".equals(pkg);
+            boolean isNCM = "com.netease.cloudmusic".equals(pkg);
 
             suppressLyricsToggle = true;
-            sw.setChecked(autoLyrics && isQQ);  // 非QQ时自动回拨为关；回到QQ且autoLyrics=true时自动打开
+            sw.setChecked(autoLyrics && (isQQ || isNCM));  // QQ或网易云时根据设置显示；其他时自动回拨为关
             suppressLyricsToggle = false;
         }
     };
@@ -249,9 +250,10 @@ public class MainActivity extends AppCompatActivity {
         SharedPreferences selSp = getSharedPreferences("session_pref", MODE_PRIVATE);
         String chosenPkg = selSp.getString("last_pkg", null);
         boolean isQQSelected = "com.tencent.qqmusic".equals(chosenPkg);
+        boolean isNCMSelected = "com.netease.cloudmusic".equals(chosenPkg);
 
-        // 只有当选择的是 QQ 且偏好为 true 才默认勾选
-        switchLyrics.setChecked(autoLyrics && isQQSelected);
+        // 只有当选择的是 QQ 或网易云且偏好为 true 才默认勾选
+        switchLyrics.setChecked(autoLyrics && (isQQSelected || isNCMSelected));
 
         switchLyrics.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (suppressLyricsToggle) return;
@@ -260,18 +262,19 @@ public class MainActivity extends AppCompatActivity {
             SharedPreferences curSel = getSharedPreferences("session_pref", MODE_PRIVATE);
             String currentPkg = curSel.getString("last_pkg", null);
             boolean isQQ = "com.tencent.qqmusic".equals(currentPkg);
+            boolean isNCM = "com.netease.cloudmusic".equals(currentPkg);
 
-            // 非 QQ 音乐：禁止开启歌词模式并回拨
-            if (!isQQ && isChecked) {
+            // 非 QQ/网易云音乐：禁止开启歌词模式并回拨
+            if (!isQQ && !isNCM && isChecked) {
                 suppressLyricsToggle = true;
                 switchLyrics.setChecked(false);   // 立刻回拨
                 suppressLyricsToggle = false;
-                Toast.makeText(MainActivity.this, "当前选择的 App 不支持歌词模式（仅 QQ 音乐）", Toast.LENGTH_SHORT).show();
+                Toast.makeText(MainActivity.this, "当前选择的 App 不支持歌词模式（仅 QQ 音乐和网易云音乐）", Toast.LENGTH_SHORT).show();
                 prefs.edit().putBoolean("autoLyrics", false).apply();
                 return;
             }
 
-            // QQ 音乐：正常落盘与通知
+            // QQ 音乐或网易云音乐：正常落盘与通知
             prefs.edit().putBoolean("autoLyrics", isChecked).apply();
             if (isChecked) {
                 // 用户开启后立即激活歌词模式（由 MyMusicService 监听本地广播）

--- a/shared/src/main/AndroidManifest.xml
+++ b/shared/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <!-- 网络权限：用于获取网易云音乐歌词 -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application android:appCategory="audio">
 
         <meta-data

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -48,6 +48,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private List<Pair<Long, String>> parsedTranslation = new ArrayList<>(); // 翻译歌词
     private boolean hasTranslation = false; // 是否有翻译歌词
     private boolean isLyricsMode = false; // 仅 QQ 模式可用；NCM 模式强制关闭
+    private boolean userWantsLyrics = false; // 用户是否想要歌词模式（记录用户意图）
     private final Handler handler = new Handler(Looper.getMainLooper());
 
     private int lastPlayMode = 0; // QQ 的播放模式缓存
@@ -66,6 +67,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private long durationMs = 0L;
 
     private String lastLyricsRaw = null;
+    private boolean isInstrumental = false;  // 标记当前歌曲是否为纯音乐
 
     // 三种模式：QQ音乐、网易云音乐、其他
     private static final String MODE_QQ = "QQ";
@@ -137,6 +139,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
             }
             if (!isLyricsMode) {
                 isLyricsMode = true;
+                userWantsLyrics = true; // 同步用户意图
                 Log.i("Mirror", "🎵 已开启歌词模式（" + musicMode + "）");
 
                 if (lastRemoteState != null) {
@@ -178,6 +181,44 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
         // --- 1. 同步元数据 ---
         if (meta != null) {
+            // 检查是否需要自动开启歌词模式（在调用 applyLyricsOverlay 之前）
+            if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && !isLyricsMode) {
+                // 检测是否是新歌曲
+                boolean isNewSong = false;
+                if (MODE_QQ.equals(musicMode)) {
+                    String lyricsWhole = meta.getString("ucar.media.metadata.LYRICS_WHOLE");
+                    isNewSong = lyricsWhole != null && !lyricsWhole.equals(lastLyricsRaw);
+                } else if (MODE_NCM.equals(musicMode)) {
+                    String mediaId = meta.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID);
+                    String cacheKey = "ncm_" + mediaId;
+                    isNewSong = mediaId != null && !cacheKey.equals(lastLyricsRaw);
+                }
+                
+                Log.i("Mirror", "[调试-mirror] isNewSong=" + isNewSong + ", isLyricsMode=" + isLyricsMode);
+                
+                if (isNewSong) {
+                    // 检查自动开启歌词设置
+                    SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+                    boolean autoLyrics = prefs.getBoolean("autoLyrics", false);
+                    
+                    if (autoLyrics) {
+                        isLyricsMode = true;
+                        userWantsLyrics = true;
+                        Log.i("Mirror", "🔄 检测到新歌曲，自动开启歌词模式");
+                        
+                        if (lastRemoteState != null) {
+                            basePosMs = lastRemoteState.getPosition();
+                            baseSpeed = lastRemoteState.getPlaybackSpeed();
+                            baseState = lastRemoteState.getState();
+                            baseUpdateElapsed = SystemClock.elapsedRealtime();
+                        }
+                        
+                        handler.post(lyricsUpdater);
+                        updateSessionActive("mirror中自动开启歌词模式");
+                    }
+                }
+            }
+            
             if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode) {
                 // QQ/网易云 歌词模式：覆盖为"当前句/下一句"
                 applyLyricsOverlay(meta);
@@ -319,9 +360,11 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
     // 在"QQ/网易云 歌词模式"调用：把当前/下一句覆盖到元数据
     private void applyLyricsOverlay(MediaMetadataCompat meta) {
-        if (MODE_OTHER.equals(musicMode) || !isLyricsMode || meta == null) return;
+        if (MODE_OTHER.equals(musicMode) || meta == null) return;
         
-        Log.i("Mirror", "📝 applyLyricsOverlay 被调用，当前 parsedLyrics.size()=" + parsedLyrics.size());
+        if (!isLyricsMode) {
+            return;
+        }
 
         // QQ 模式有 playMode
         if (MODE_QQ.equals(musicMode)) {
@@ -335,8 +378,42 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         String lyricsWhole = null;
         if (MODE_QQ.equals(musicMode)) {
             lyricsWhole = meta.getString("ucar.media.metadata.LYRICS_WHOLE");
+            Log.i("Mirror", "[调试] QQ模式, lyricsWhole!=null: " + (lyricsWhole != null) + ", lastLyricsRaw=" + lastLyricsRaw);
+            
             if (lyricsWhole != null && !lyricsWhole.equals(lastLyricsRaw)) {
-                // 切歌了，立即清空旧歌词并解析新歌词
+                Log.i("Mirror", "[调试] QQ模式检测到新歌曲");
+                // 切歌了，检查是否需要自动开启歌词模式
+                SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+                boolean autoLyrics = prefs.getBoolean("autoLyrics", false);
+                Log.i("Mirror", "[调试] autoLyrics=" + autoLyrics + ", isLyricsMode=" + isLyricsMode);
+                
+                if (autoLyrics && !isLyricsMode) {
+                    isLyricsMode = true;
+                    userWantsLyrics = true;
+                    Log.i("Mirror", "🎵 检测到新歌曲，自动开启歌词模式");
+                    
+                    if (lastRemoteState != null) {
+                        basePosMs = lastRemoteState.getPosition();
+                        baseSpeed = lastRemoteState.getPlaybackSpeed();
+                        baseState = lastRemoteState.getState();
+                        baseUpdateElapsed = SystemClock.elapsedRealtime();
+                    }
+                    
+                    // 立即清空旧歌词并解析新歌词
+                    parsedLyrics.clear();
+                    lastLyricsRaw = lyricsWhole;
+                    parseLyrics(lyricsWhole);
+                    
+                    handler.post(lyricsUpdater);
+                    // 重新调用mirror触发更新
+                    if (remoteCtrl != null) {
+                        mirror(remoteCtrl.getMetadata(), remoteCtrl.getPlaybackState());
+                    }
+                    updateSessionActive("自动开启歌词模式");
+                    return; // 已经处理完，直接返回
+                }
+                
+                // 立即清空旧歌词并解析新歌词
                 parsedLyrics.clear();
                 lastLyricsRaw = lyricsWhole;
                 parseLyrics(lyricsWhole);
@@ -346,10 +423,47 @@ public class MyMusicService extends MediaBrowserServiceCompat {
             String mediaId = meta.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID);
             String cacheKey = "ncm_" + mediaId;
             
-            Log.i("Mirror", "🔍 检查网易云歌词，mediaId=" + mediaId + ", cacheKey=" + cacheKey + ", lastLyricsRaw=" + lastLyricsRaw);
-            
             if (mediaId != null && !cacheKey.equals(lastLyricsRaw)) {
-                // 切歌了，立即清空旧歌词并显示加载提示
+                Log.i("Mirror", "[调试] 网易云模式检测到新歌曲");
+                // 切歌了，检查是否需要自动开启歌词模式
+                SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
+                boolean autoLyrics = prefs.getBoolean("autoLyrics", false);
+                Log.i("Mirror", "[调试] autoLyrics=" + autoLyrics + ", isLyricsMode=" + isLyricsMode);
+                
+                if (autoLyrics && !isLyricsMode) {
+                    isLyricsMode = true;
+                    userWantsLyrics = true;
+                    Log.i("Mirror", "🎵 检测到新歌曲，自动开启歌词模式");
+                    
+                    if (lastRemoteState != null) {
+                        basePosMs = lastRemoteState.getPosition();
+                        baseSpeed = lastRemoteState.getPlaybackSpeed();
+                        baseState = lastRemoteState.getState();
+                        baseUpdateElapsed = SystemClock.elapsedRealtime();
+                    }
+                    
+                    // 立即清空旧歌词并显示加载提示
+                    Log.i("Mirror", "🆕 检测到新歌曲，清空旧歌词");
+                    parsedLyrics.clear();
+                    parsedTranslation.clear();
+                    hasTranslation = false;
+                    parsedLyrics.add(new Pair<>(0L, "🎵 歌词加载中..."));
+                    parsedLyrics.add(new Pair<>(3000L, "请稍候"));
+                    lastLyricsRaw = cacheKey;
+                    
+                    // 异步获取新歌词
+                    fetchNcmLyrics(mediaId);
+                    
+                    handler.post(lyricsUpdater);
+                    // 重新调用mirror触发更新
+                    if (remoteCtrl != null) {
+                        mirror(remoteCtrl.getMetadata(), remoteCtrl.getPlaybackState());
+                    }
+                    updateSessionActive("自动开启歌词模式");
+                    return; // 已经处理完，直接返回
+                }
+                
+                // 立即清空旧歌词并显示加载提示
                 Log.i("Mirror", "🆕 检测到新歌曲，清空旧歌词");
                 parsedLyrics.clear();
                 parsedTranslation.clear();
@@ -361,7 +475,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 // 异步获取新歌词
                 fetchNcmLyrics(mediaId);
             } else {
-                Log.i("Mirror", "♻️ 同一首歌，使用缓存歌词，parsedLyrics.size()=" + parsedLyrics.size());
+                // Log.i("Mirror", "♻️ 同一首歌，使用缓存歌词，parsedLyrics.size()=" + parsedLyrics.size());
             }
             // 如果是同一首歌，继续使用已缓存的歌词
         }
@@ -400,7 +514,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
             }
         }
         
-        Log.i("Mirror", "🎤 显示歌词 - 当前: \"" + current + "\" | 下一句: \"" + next + "\" | 时间=" + t + "ms");
+        // Log.i("Mirror", "🎤 显示歌词 - 当前: \"" + current + "\" | 下一句: \"" + next + "\" | 时间=" + t + "ms");
 
         MediaMetadataCompat.Builder b = new MediaMetadataCompat.Builder();
         b.putString(MediaMetadataCompat.METADATA_KEY_TITLE, current);
@@ -487,6 +601,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 if (MODE_OTHER.equals(musicMode)) {
                     if (isLyricsMode) {
                         isLyricsMode = false;
+                        userWantsLyrics = false; // 重置用户意图
                         handler.removeCallbacks(lyricsUpdater);
                         suppressRemoteState = false;
                         Log.i("Mirror", "🧹 已关闭歌词模式并清理定时任务（进入其他模式）");
@@ -528,7 +643,30 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
     private void parseLyrics(String rawLyrics) {
         parsedLyrics.clear();
+        isInstrumental = false;  // 重置纯音乐标志
+        
         Log.i("Mirror", "📋 开始解析歌词，原始长度=" + rawLyrics.length());
+        
+        // 检测是否为纯音乐
+        if (rawLyrics != null && rawLyrics.contains("纯音乐，请欣赏")) {
+            isInstrumental = true;
+            Log.i("Mirror", "🎼 检测到纯音乐，自动关闭歌词模式, 当前isLyricsMode=" + isLyricsMode);
+            
+            // 自动关闭歌词模式（模拟点击歌词按钮）
+            if (isLyricsMode) {
+                isLyricsMode = false;
+                handler.removeCallbacks(lyricsUpdater);
+                suppressRemoteState = false;
+                
+                // 触发mirror更新，恢复正常显示
+                if (remoteCtrl != null) {
+                    mirror(remoteCtrl.getMetadata(), remoteCtrl.getPlaybackState());
+                }
+                updateSessionActive("纯音乐自动关闭歌词模式");
+            }
+            return;  // 纯音乐不需要解析歌词
+        }
+        
         // 支持任意位数小数的时间戳格式: [00:24.28] [00:24.287] [00:24.2] 等
         Pattern pattern = Pattern.compile("\\[(\\d{2}):(\\d{2}\\.\\d+)\\](.*)");
         int matchCount = 0;
@@ -544,6 +682,25 @@ public class MyMusicService extends MediaBrowserServiceCompat {
             }
         }
         Log.i("Mirror", "✅ 歌词解析完成，共解析 " + matchCount + " 行，parsedLyrics.size()=" + parsedLyrics.size());
+        
+        // 如果用户想要歌词模式，但当前被纯音乐关闭了，重新开启
+        if (userWantsLyrics && !isLyricsMode) {
+            isLyricsMode = true;
+            Log.i("Mirror", "🔄 检测到正常歌曲，恢复歌词模式");
+            
+            if (lastRemoteState != null) {
+                basePosMs = lastRemoteState.getPosition();
+                baseSpeed = lastRemoteState.getPlaybackSpeed();
+                baseState = lastRemoteState.getState();
+                baseUpdateElapsed = SystemClock.elapsedRealtime();
+            }
+            
+            handler.post(lyricsUpdater);
+            if (remoteCtrl != null) {
+                mirror(remoteCtrl.getMetadata(), remoteCtrl.getPlaybackState());
+            }
+            updateSessionActive("恢复歌词模式");
+        }
     }
     
     private void parseTranslation(String rawLyrics) {
@@ -728,6 +885,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
                 if (CUSTOM_ACTION_SHOW_LYRICS.equals(action)) {
                     isLyricsMode = !isLyricsMode;
+                    userWantsLyrics = isLyricsMode; // 同步用户意图
 
                     if (isLyricsMode) {
                         if (lastRemoteState != null) {
@@ -779,6 +937,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         Log.i("Mirror", "🎚 autoLyrics 开关状态 = " + autoLyrics);
         if (autoLyrics && (MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && !isLyricsMode) {
             isLyricsMode = true;
+            userWantsLyrics = true; // 同步用户意图
 
             if (lastRemoteState != null) {
                 basePosMs = lastRemoteState.getPosition();

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -45,6 +45,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private static final String ACTION_TOGGLE_LYRICS_MODE = "com.nuomi.ACTION_TOGGLE_LYRICS_MODE";
 
     private List<Pair<Long, String>> parsedLyrics = new ArrayList<>();
+    private List<Pair<Long, String>> parsedTranslation = new ArrayList<>(); // 翻译歌词
+    private boolean hasTranslation = false; // 是否有翻译歌词
     private boolean isLyricsMode = false; // 仅 QQ 模式可用；NCM 模式强制关闭
     private final Handler handler = new Handler(Looper.getMainLooper());
 
@@ -350,6 +352,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 // 切歌了，立即清空旧歌词并显示加载提示
                 Log.i("Mirror", "🆕 检测到新歌曲，清空旧歌词");
                 parsedLyrics.clear();
+                parsedTranslation.clear();
+                hasTranslation = false;
                 parsedLyrics.add(new Pair<>(0L, "🎵 歌词加载中..."));
                 parsedLyrics.add(new Pair<>(3000L, "请稍候"));
                 lastLyricsRaw = cacheKey;
@@ -376,8 +380,24 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 if (parsedLyrics.get(mid).first <= t) { ans = mid; lo = mid + 1; }
                 else hi = mid - 1;
             }
-            if (ans >= 0) current = parsedLyrics.get(ans).second;
-            if (ans + 1 < parsedLyrics.size()) next = parsedLyrics.get(ans + 1).second;
+            
+            if (ans >= 0) {
+                String originalLine = parsedLyrics.get(ans).second;
+                
+                // 判断是否需要显示翻译：有翻译且原文不是中英文
+                if (hasTranslation && !isChinseOrEnglish(originalLine)) {
+                    // 非中英文歌曲：上面显示翻译，下面显示原文
+                    String translatedLine = getTranslationAt(t);
+                    current = translatedLine != null ? translatedLine : originalLine;
+                    next = originalLine;
+                } else {
+                    // 中英文歌曲：显示当前句和下一句
+                    current = originalLine;
+                    if (ans + 1 < parsedLyrics.size()) {
+                        next = parsedLyrics.get(ans + 1).second;
+                    }
+                }
+            }
         }
         
         Log.i("Mirror", "🎤 显示歌词 - 当前: \"" + current + "\" | 下一句: \"" + next + "\" | 时间=" + t + "ms");
@@ -525,19 +545,93 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         }
         Log.i("Mirror", "✅ 歌词解析完成，共解析 " + matchCount + " 行，parsedLyrics.size()=" + parsedLyrics.size());
     }
+    
+    private void parseTranslation(String rawLyrics) {
+        parsedTranslation.clear();
+        Pattern pattern = Pattern.compile("\\[(\\d{2}):(\\d{2}\\.\\d+)\\](.*)");
+        for (String line : rawLyrics.split("\n")) {
+            Matcher matcher = pattern.matcher(line);
+            if (matcher.find()) {
+                int min = Integer.parseInt(matcher.group(1));
+                float sec = Float.parseFloat(matcher.group(2));
+                long timeMs = (long) ((min * 60 + sec) * 1000);
+                String text = matcher.group(3).trim();
+                parsedTranslation.add(new Pair<>(timeMs, text));
+            }
+        }
+    }
 
+    // 判断是否为中文或英文
+    private boolean isChinseOrEnglish(String text) {
+        if (text == null || text.isEmpty()) return true;
+        
+        // 检测日文假名(平假名或片假名)
+        for (char c : text.toCharArray()) {
+            Character.UnicodeBlock block = Character.UnicodeBlock.of(c);
+            if (block == Character.UnicodeBlock.HIRAGANA || 
+                block == Character.UnicodeBlock.KATAKANA) {
+                return false; // 包含日文假名,不是中英文
+            }
+        }
+        
+        // 检查是否包含中文字符
+        boolean hasChinese = false;
+        for (char c : text.toCharArray()) {
+            if (Character.UnicodeBlock.of(c) == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS) {
+                hasChinese = true;
+                break;
+            }
+        }
+        
+        // 如果有中文或主要是ASCII,认为是中英文
+        if (hasChinese) return true;
+        
+        int asciiCount = 0;
+        for (char c : text.toCharArray()) {
+            if (c >= 32 && c <= 126) asciiCount++;
+        }
+        return asciiCount > text.length() * 0.8; // 超过80%是ASCII认为是英文
+    }
+    
+    // 获取指定时间的翻译歌词
+    private String getTranslationAt(long timeMs) {
+        if (parsedTranslation.isEmpty()) return null;
+        int lo = 0, hi = parsedTranslation.size() - 1, ans = -1;
+        while (lo <= hi) {
+            int mid = (lo + hi) >>> 1;
+            if (parsedTranslation.get(mid).first <= timeMs) {
+                ans = mid;
+                lo = mid + 1;
+            } else {
+                hi = mid - 1;
+            }
+        }
+        return ans >= 0 ? parsedTranslation.get(ans).second : null;
+    }
+    
     // 异步获取网易云音乐歌词
     private void fetchNcmLyrics(String mediaId) {
         Log.i("Mirror", "🎵 开始获取网易云歌词，mediaId=" + mediaId);
         
         NcmLyricsHelper.fetchLyrics(mediaId, new NcmLyricsHelper.LyricsCallback() {
             @Override
-            public void onSuccess(String lyrics) {
+            public void onSuccess(String lyrics, String translation) {
                 Log.i("Mirror", "✅ 网易云歌词获取成功，歌词长度=" + lyrics.length());
                 Log.i("Mirror", "📝 歌词原始内容前100字符: " + lyrics.substring(0, Math.min(100, lyrics.length())));
-                // 解析歌词（这会替换掉"加载中"的临时歌词）
+                
+                // 解析原文歌词
                 parseLyrics(lyrics);
                 Log.i("Mirror", "🔍 解析后 parsedLyrics 数量=" + parsedLyrics.size());
+                
+                // 解析翻译歌词（如果存在）
+                if (translation != null && !translation.isEmpty()) {
+                    parseTranslation(translation);
+                    hasTranslation = true;
+                    Log.i("Mirror", "🌐 翻译歌词解析完成，数量=" + parsedTranslation.size());
+                } else {
+                    parsedTranslation.clear();
+                    hasTranslation = false;
+                }
                 
                 // 强制刷新显示：直接调用歌词更新器
                 handler.post(lyricsUpdater);

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -509,7 +509,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private void parseLyrics(String rawLyrics) {
         parsedLyrics.clear();
         Log.i("Mirror", "📋 开始解析歌词，原始长度=" + rawLyrics.length());
-        Pattern pattern = Pattern.compile("\\[(\\d{2}):(\\d{2}\\.\\d{2})\\](.*)");
+        // 支持任意位数小数的时间戳格式: [00:24.28] [00:24.287] [00:24.2] 等
+        Pattern pattern = Pattern.compile("\\[(\\d{2}):(\\d{2}\\.\\d+)\\](.*)");
         int matchCount = 0;
         for (String line : rawLyrics.split("\n")) {
             Matcher matcher = pattern.matcher(line);

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -537,6 +537,14 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         MediaMetadataCompat.Builder b = new MediaMetadataCompat.Builder();
         b.putString(MediaMetadataCompat.METADATA_KEY_TITLE, current);
         b.putString(MediaMetadataCompat.METADATA_KEY_ARTIST, next);
+        
+        String originalTitle = meta.getString(MediaMetadataCompat.METADATA_KEY_TITLE);
+        String originalArtist = meta.getString(MediaMetadataCompat.METADATA_KEY_ARTIST);
+        if (originalTitle != null && originalArtist != null) {
+            b.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, originalTitle + " - " + originalArtist);
+        } else if (originalTitle != null) {
+            b.putString(MediaMetadataCompat.METADATA_KEY_ALBUM, originalTitle);
+        }
 
         Bitmap art = meta.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART);
         if (art != null) b.putBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART, art);
@@ -1079,9 +1087,26 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 for (android.media.session.MediaController c : byPkg.values()) {
                     String pkg = c.getPackageName();
                     String label = pkg;
+                    Bitmap icon = null;
                     try {
-                        label = getPackageManager().getApplicationLabel(
-                                getPackageManager().getApplicationInfo(pkg, 0)).toString();
+                        android.content.pm.ApplicationInfo appInfo = getPackageManager().getApplicationInfo(pkg, 0);
+                        label = getPackageManager().getApplicationLabel(appInfo).toString();
+                        // 获取应用图标
+                        android.graphics.drawable.Drawable drawable = getPackageManager().getApplicationIcon(appInfo);
+                        if (drawable instanceof android.graphics.drawable.BitmapDrawable) {
+                            icon = ((android.graphics.drawable.BitmapDrawable) drawable).getBitmap();
+                        } else {
+                            // 转换 Drawable 为 Bitmap
+                            int w = drawable.getIntrinsicWidth();
+                            int h = drawable.getIntrinsicHeight();
+                            if (w > 0 && h > 0) {
+                                Bitmap bmp = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888);
+                                android.graphics.Canvas canvas = new android.graphics.Canvas(bmp);
+                                drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+                                drawable.draw(canvas);
+                                icon = bmp;
+                            }
+                        }
                     } catch (Exception ignore) {}
                     
                     String nowPlaying = null;
@@ -1093,13 +1118,16 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                     
                     String subtitle = nowPlaying != null ? "正在播放: " + nowPlaying : "点击选择此播放器";
                     
-                    MediaDescriptionCompat desc = new MediaDescriptionCompat.Builder()
+                    MediaDescriptionCompat.Builder descBuilder = new MediaDescriptionCompat.Builder()
                             .setMediaId(pkg)
                             .setTitle(label)
-                            .setSubtitle(subtitle)
-                            .build();
+                            .setSubtitle(subtitle);
                     
-                    items.add(new MediaBrowserCompat.MediaItem(desc,
+                    if (icon != null) {
+                        descBuilder.setIconBitmap(icon);
+                    }
+                    
+                    items.add(new MediaBrowserCompat.MediaItem(descBuilder.build(),
                             MediaBrowserCompat.MediaItem.FLAG_PLAYABLE));
                 }
                 

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -65,8 +65,11 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
     private String lastLyricsRaw = null;
 
-    // 新增：当前是否处于“网易云模式”
-    private boolean isNcmMode = false;  // false=QQ 模式；true=非QQ（任意播放器）模式
+    // 三种模式：QQ音乐、网易云音乐、其他
+    private static final String MODE_QQ = "QQ";
+    private static final String MODE_NCM = "NCM";
+    private static final String MODE_OTHER = "OTHER";
+    private String musicMode = MODE_QQ;  // 当前模式，默认QQ音乐
 
     // 新增：防止重复激活
     private boolean sessionActivated = false;
@@ -75,7 +78,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private static final String TAG = "Mirror";
 
     private void updateSessionActive(String reason) {
-        boolean should = (!isNcmMode && isLyricsMode); // 只有 QQ + 歌词模式 才激活
+        // QQ 或 网易云 + 歌词模式 才激活
+        boolean should = ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode);
         if (mSession.isActive() != should) {
             mSession.setActive(should);
             Log.i(TAG, "setActive=" + should + " reason=" + reason);
@@ -109,29 +113,29 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         }
     }
 
-    // 每秒刷新（仅 QQ 歌词模式）
+    // 每秒刷新（QQ 和网易云歌词模式）
     private final Runnable lyricsUpdater = new Runnable() {
         @Override
         public void run() {
-            if (!isNcmMode && isLyricsMode && remoteCtrl != null) {
+            if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode && remoteCtrl != null) {
                 applyLyricsOverlay(lastRemoteMeta);
                 handler.postDelayed(this, 1000);
             }
         }
     };
 
-    // “自动开启歌词模式”广播，仅 QQ 模式生效
+    // "自动开启歌词模式"广播，QQ 和网易云模式生效
     private final BroadcastReceiver autoLyricsReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
             Log.i("Mirror", "📨 收到自动开启歌词模式请求");
-            if (isNcmMode) { // 非QQ模式
-                Log.i("Mirror", "ℹ️ 当前为【非 QQ 模式】，忽略开启歌词模式请求");
+            if (MODE_OTHER.equals(musicMode)) { // 其他模式不支持歌词
+                Log.i("Mirror", "ℹ️ 当前为【其他模式】，忽略开启歌词模式请求");
                 return;
             }
             if (!isLyricsMode) {
                 isLyricsMode = true;
-                Log.i("Mirror", "🎵 已开启歌词模式（QQ）");
+                Log.i("Mirror", "🎵 已开启歌词模式（" + musicMode + "）");
 
                 if (lastRemoteState != null) {
                     basePosMs = lastRemoteState.getPosition();
@@ -172,11 +176,11 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
         // --- 1. 同步元数据 ---
         if (meta != null) {
-            if (!isNcmMode && isLyricsMode) {
-                // QQ 歌词模式：覆盖为“当前句/下一句”
+            if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode) {
+                // QQ/网易云 歌词模式：覆盖为"当前句/下一句"
                 applyLyricsOverlay(meta);
             } else {
-                // QQ 非歌词模式 或 NCM 模式：原样映射标准字段
+                // QQ/网易云 非歌词模式 或 其他模式：原样映射标准字段
                 MediaMetadataCompat.Builder builder = new MediaMetadataCompat.Builder();
 
                 String title = meta.getString(MediaMetadataCompat.METADATA_KEY_TITLE);
@@ -184,8 +188,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
                 long duration = meta.getLong(MediaMetadataCompat.METADATA_KEY_DURATION);
 
-                // QQ 模式保留 playMode；NCM 没有该私有键，忽略即可
-                if (!isNcmMode) {
+                // QQ 模式保留 playMode；网易云/其他 没有该私有键，忽略即可
+                if (MODE_QQ.equals(musicMode)) {
                     long playMode = meta.getLong("ucar.media.metadata.PLAY_MODE");
                     lastPlayMode = (int) playMode;
                 }
@@ -198,7 +202,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
                 // ✅ 仅在“非 QQ 模式”启用封面位图兜底；QQ 模式保持你原来的只取 ALBUM_ART 行为
                 Bitmap art = null;
-                if (isNcmMode) {
+                if (!MODE_QQ.equals(musicMode)) {
                     // 非 QQ：位图优先顺序 ALBUM_ART → DISPLAY_ICON → ART
                     art = meta.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART);
                     if (art == null) art = meta.getBitmap(MediaMetadataCompat.METADATA_KEY_DISPLAY_ICON);
@@ -219,8 +223,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         // --- 2. 同步播放状态 ---
         if (st != null) {
 
-            // QQ 歌词模式专用分支（NCM 模式强制关闭歌词，不走此分支）
-            if (!isNcmMode && isLyricsMode) {
+            // QQ/网易云 歌词模式专用分支（其他模式强制关闭歌词，不走此分支）
+            if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode) {
                 if (!suppressRemoteState) {
                     basePosMs = st.getPosition();
                     baseSpeed = st.getPlaybackSpeed();
@@ -244,20 +248,23 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                                         PlaybackStateCompat.ACTION_PLAY_PAUSE
                         );
 
-                // 自定义按钮（仅 QQ 模式展示）
+                // 自定义按钮（QQ 和网易云模式展示）
                 int lyricsIconRes = isLyricsMode ? R.drawable.ic_lyrics_24dp : R.drawable.ic_lyrics_outline_24dp;
                 builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
                         CUSTOM_ACTION_SHOW_LYRICS, "歌词", lyricsIconRes).build());
 
-                int repeatIconRes;
-                switch (lastPlayMode) {
-                    case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
-                    case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
-                    case 2:
-                    default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+                // 循环按钮仅 QQ 模式显示
+                if (MODE_QQ.equals(musicMode)) {
+                    int repeatIconRes;
+                    switch (lastPlayMode) {
+                        case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
+                        case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
+                        case 2:
+                        default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+                    }
+                    builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
+                            CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
                 }
-                builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
-                        CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
 
                 mSession.setPlaybackState(builder.build());
                 return;
@@ -282,39 +289,52 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                     );
 
             // 仅 QQ 模式下加入自定义按钮；NCM 模式完全关闭“歌词/循环”按钮
-            if (!isNcmMode) {
+            if (MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) {
                 int lyricsIconRes = isLyricsMode ? R.drawable.ic_lyrics_24dp : R.drawable.ic_lyrics_outline_24dp;
                 builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
                         CUSTOM_ACTION_SHOW_LYRICS, "歌词", lyricsIconRes).build());
 
-                int repeatIconRes = R.drawable.ic_repeat_24dp;
-                if (meta != null) {
-                    long playMode = meta.getLong("ucar.media.metadata.PLAY_MODE");
-                    switch ((int) playMode) {
-                        case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
-                        case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
-                        case 2:
-                        default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+                // 循环按钮仅 QQ 模式显示
+                if (MODE_QQ.equals(musicMode)) {
+                    int repeatIconRes = R.drawable.ic_repeat_24dp;
+                    if (meta != null) {
+                        long playMode = meta.getLong("ucar.media.metadata.PLAY_MODE");
+                        switch ((int) playMode) {
+                            case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
+                            case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
+                            case 2:
+                            default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+                        }
                     }
+                    builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
+                            CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
                 }
-                builder.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
-                        CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
             }
 
             mSession.setPlaybackState(builder.build());
         }
     }
 
-    // 仅在“QQ 歌词模式”调用：把当前/下一句覆盖到元数据
+    // 在"QQ/网易云 歌词模式"调用：把当前/下一句覆盖到元数据
     private void applyLyricsOverlay(MediaMetadataCompat meta) {
-        if (isNcmMode || !isLyricsMode || meta == null) return;
+        if (MODE_OTHER.equals(musicMode) || !isLyricsMode || meta == null) return;
 
-        long playMode = meta.getLong("ucar.media.metadata.PLAY_MODE");
-        lastPlayMode = (int) playMode;
+        // QQ 模式有 playMode
+        if (MODE_QQ.equals(musicMode)) {
+            long playMode = meta.getLong("ucar.media.metadata.PLAY_MODE");
+            lastPlayMode = (int) playMode;
+        }
         long dur = meta.getLong(MediaMetadataCompat.METADATA_KEY_DURATION);
         if (dur > 0) durationMs = dur;
 
-        String lyricsWhole = meta.getString("ucar.media.metadata.LYRICS_WHOLE");
+        // 获取歌词：QQ 模式从元数据获取，网易云模式使用占位歌词
+        String lyricsWhole = null;
+        if (MODE_QQ.equals(musicMode)) {
+            lyricsWhole = meta.getString("ucar.media.metadata.LYRICS_WHOLE");
+        } else if (MODE_NCM.equals(musicMode)) {
+            lyricsWhole = getNcmPlaceholderLyrics();
+        }
+        
         if (lyricsWhole != null && !lyricsWhole.equals(lastLyricsRaw)) {
             lastLyricsRaw = lyricsWhole;
             parseLyrics(lyricsWhole);
@@ -361,15 +381,18 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         ps.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
                 CUSTOM_ACTION_SHOW_LYRICS, "歌词", lyricsIconRes).build());
 
-        int repeatIconRes;
-        switch (lastPlayMode) {
-            case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
-            case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
-            case 2:
-            default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+        // 循环按钮仅 QQ 模式显示
+        if (MODE_QQ.equals(musicMode)) {
+            int repeatIconRes;
+            switch (lastPlayMode) {
+                case 1: repeatIconRes = R.drawable.ic_repeat_one_24dp; break;
+                case 0: repeatIconRes = R.drawable.ic_shuffle_24dp;    break;
+                case 2:
+                default: repeatIconRes = R.drawable.ic_repeat_24dp;    break;
+            }
+            ps.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
+                    CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
         }
-        ps.addCustomAction(new PlaybackStateCompat.CustomAction.Builder(
-                CUSTOM_ACTION_REPEAT_MODE, "循环", repeatIconRes).build());
 
         mSession.setPlaybackState(ps.build());
     }
@@ -396,20 +419,29 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 return;
             }
 
-            // 3) 根据来源是否 QQ 切换模式（非 QQ → 旧 NCM 逻辑）
-            boolean toNonQqMode = !"com.tencent.qqmusic".equals(sourcePkg);
-            if (toNonQqMode != isNcmMode) {
-                isNcmMode = toNonQqMode;
-                if (isNcmMode) {
-                    Log.i("Mirror", "🔄 切换为【非 QQ 模式】（禁用歌词/自定义按钮），来源=" + sourcePkg);
+            // 3) 根据来源包名确定模式：QQ、网易云或其他
+            String newMode;
+            if ("com.tencent.qqmusic".equals(sourcePkg)) {
+                newMode = MODE_QQ;
+            } else if ("com.netease.cloudmusic".equals(sourcePkg)) {
+                newMode = MODE_NCM;
+            } else {
+                newMode = MODE_OTHER;
+            }
+            
+            if (!newMode.equals(musicMode)) {
+                String oldMode = musicMode;
+                musicMode = newMode;
+                Log.i("Mirror", "🔄 切换为【" + musicMode + " 模式】，来源=" + sourcePkg);
+                
+                // 如果切换到"其他"模式，关闭歌词
+                if (MODE_OTHER.equals(musicMode)) {
                     if (isLyricsMode) {
                         isLyricsMode = false;
                         handler.removeCallbacks(lyricsUpdater);
                         suppressRemoteState = false;
-                        Log.i("Mirror", "🧹 已关闭歌词模式并清理定时任务（进入非QQ）");
+                        Log.i("Mirror", "🧹 已关闭歌词模式并清理定时任务（进入其他模式）");
                     }
-                } else {
-                    Log.i("Mirror", "🔄 切换为【QQ 模式】（可用歌词/自定义按钮）");
                 }
             }
 
@@ -460,6 +492,16 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         }
     }
 
+    // 网易云音乐歌词占位函数：返回固定的示例歌词
+    private String getNcmPlaceholderLyrics() {
+        return "[00:00.00]网易云音乐歌词显示功能\n" +
+               "[00:03.00]这是一段示例歌词\n" +
+               "[00:06.00]🎵 当前播放的是网易云音乐\n" +
+               "[00:10.00]歌词功能开发中\n" +
+               "[00:14.00]敬请期待\n" +
+               "[00:18.00]感谢使用糯米播放器";
+    }
+
     // =========================================================
     // 🚀 启动服务：初始化本地 MediaSession 并设置转发逻辑
     // =========================================================
@@ -502,7 +544,7 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                     remoteCtrl.getTransportControls().seekTo(positionMs);
                 }
 
-                if (!isNcmMode && isLyricsMode) {
+                if ((MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && isLyricsMode) {
                     suppressRemoteState = true;
                     handler.removeCallbacks(clearSuppression);
                     handler.postDelayed(clearSuppression, 1200);
@@ -528,8 +570,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
             @Override
             public void onCustomAction(String action, Bundle extras) {
-                // NCM 模式下直接忽略自定义按钮
-                if (isNcmMode) return;
+                // 其他模式下直接忽略自定义按钮
+                if (MODE_OTHER.equals(musicMode)) return;
 
                 if (CUSTOM_ACTION_SHOW_LYRICS.equals(action)) {
                     isLyricsMode = !isLyricsMode;
@@ -578,11 +620,11 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         lbm.registerReceiver(autoLyricsReceiver, new IntentFilter(ACTION_TOGGLE_LYRICS_MODE));
 
 
-        // 自动歌词模式：仅在 QQ 模式下可自动开启（NCM 模式忽略）
+        // 自动歌词模式：QQ 和网易云模式可自动开启
         SharedPreferences prefs = getSharedPreferences("settings", MODE_PRIVATE);
         boolean autoLyrics = prefs.getBoolean("autoLyrics", false);
         Log.i("Mirror", "🎚 autoLyrics 开关状态 = " + autoLyrics);
-        if (autoLyrics && !isNcmMode && !isLyricsMode) {
+        if (autoLyrics && (MODE_QQ.equals(musicMode) || MODE_NCM.equals(musicMode)) && !isLyricsMode) {
             isLyricsMode = true;
 
             if (lastRemoteState != null) {

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -318,6 +318,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     // 在"QQ/网易云 歌词模式"调用：把当前/下一句覆盖到元数据
     private void applyLyricsOverlay(MediaMetadataCompat meta) {
         if (MODE_OTHER.equals(musicMode) || !isLyricsMode || meta == null) return;
+        
+        Log.i("Mirror", "📝 applyLyricsOverlay 被调用，当前 parsedLyrics.size()=" + parsedLyrics.size());
 
         // QQ 模式有 playMode
         if (MODE_QQ.equals(musicMode)) {
@@ -327,17 +329,42 @@ public class MyMusicService extends MediaBrowserServiceCompat {
         long dur = meta.getLong(MediaMetadataCompat.METADATA_KEY_DURATION);
         if (dur > 0) durationMs = dur;
 
-        // 获取歌词：QQ 模式从元数据获取，网易云模式使用占位歌词
+        // 获取歌词：QQ 模式从元数据获取，网易云模式从 API 获取
         String lyricsWhole = null;
         if (MODE_QQ.equals(musicMode)) {
             lyricsWhole = meta.getString("ucar.media.metadata.LYRICS_WHOLE");
+            if (lyricsWhole != null && !lyricsWhole.equals(lastLyricsRaw)) {
+                // 切歌了，立即清空旧歌词并解析新歌词
+                parsedLyrics.clear();
+                lastLyricsRaw = lyricsWhole;
+                parseLyrics(lyricsWhole);
+            }
         } else if (MODE_NCM.equals(musicMode)) {
-            lyricsWhole = getNcmPlaceholderLyrics();
+            // 网易云音乐：从 API 异步获取歌词
+            String mediaId = meta.getString(MediaMetadataCompat.METADATA_KEY_MEDIA_ID);
+            String cacheKey = "ncm_" + mediaId;
+            
+            Log.i("Mirror", "🔍 检查网易云歌词，mediaId=" + mediaId + ", cacheKey=" + cacheKey + ", lastLyricsRaw=" + lastLyricsRaw);
+            
+            if (mediaId != null && !cacheKey.equals(lastLyricsRaw)) {
+                // 切歌了，立即清空旧歌词并显示加载提示
+                Log.i("Mirror", "🆕 检测到新歌曲，清空旧歌词");
+                parsedLyrics.clear();
+                parsedLyrics.add(new Pair<>(0L, "🎵 歌词加载中..."));
+                parsedLyrics.add(new Pair<>(3000L, "请稍候"));
+                lastLyricsRaw = cacheKey;
+                
+                // 异步获取新歌词
+                fetchNcmLyrics(mediaId);
+            } else {
+                Log.i("Mirror", "♻️ 同一首歌，使用缓存歌词，parsedLyrics.size()=" + parsedLyrics.size());
+            }
+            // 如果是同一首歌，继续使用已缓存的歌词
         }
         
-        if (lyricsWhole != null && !lyricsWhole.equals(lastLyricsRaw)) {
-            lastLyricsRaw = lyricsWhole;
-            parseLyrics(lyricsWhole);
+        // 如果歌词为空，直接返回（避免显示空白）
+        if (parsedLyrics.isEmpty()) {
+            return;
         }
 
         long t = clockPosition();
@@ -352,6 +379,8 @@ public class MyMusicService extends MediaBrowserServiceCompat {
             if (ans >= 0) current = parsedLyrics.get(ans).second;
             if (ans + 1 < parsedLyrics.size()) next = parsedLyrics.get(ans + 1).second;
         }
+        
+        Log.i("Mirror", "🎤 显示歌词 - 当前: \"" + current + "\" | 下一句: \"" + next + "\" | 时间=" + t + "ms");
 
         MediaMetadataCompat.Builder b = new MediaMetadataCompat.Builder();
         b.putString(MediaMetadataCompat.METADATA_KEY_TITLE, current);
@@ -479,7 +508,9 @@ public class MyMusicService extends MediaBrowserServiceCompat {
 
     private void parseLyrics(String rawLyrics) {
         parsedLyrics.clear();
+        Log.i("Mirror", "📋 开始解析歌词，原始长度=" + rawLyrics.length());
         Pattern pattern = Pattern.compile("\\[(\\d{2}):(\\d{2}\\.\\d{2})\\](.*)");
+        int matchCount = 0;
         for (String line : rawLyrics.split("\n")) {
             Matcher matcher = pattern.matcher(line);
             if (matcher.find()) {
@@ -488,18 +519,45 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                 long timeMs = (long) ((min * 60 + sec) * 1000);
                 String text = matcher.group(3).trim();
                 parsedLyrics.add(new Pair<>(timeMs, text));
+                matchCount++;
             }
         }
+        Log.i("Mirror", "✅ 歌词解析完成，共解析 " + matchCount + " 行，parsedLyrics.size()=" + parsedLyrics.size());
     }
 
-    // 网易云音乐歌词占位函数：返回固定的示例歌词
+    // 异步获取网易云音乐歌词
+    private void fetchNcmLyrics(String mediaId) {
+        Log.i("Mirror", "🎵 开始获取网易云歌词，mediaId=" + mediaId);
+        
+        NcmLyricsHelper.fetchLyrics(mediaId, new NcmLyricsHelper.LyricsCallback() {
+            @Override
+            public void onSuccess(String lyrics) {
+                Log.i("Mirror", "✅ 网易云歌词获取成功，歌词长度=" + lyrics.length());
+                Log.i("Mirror", "📝 歌词原始内容前100字符: " + lyrics.substring(0, Math.min(100, lyrics.length())));
+                // 解析歌词（这会替换掉"加载中"的临时歌词）
+                parseLyrics(lyrics);
+                Log.i("Mirror", "🔍 解析后 parsedLyrics 数量=" + parsedLyrics.size());
+                
+                // 强制刷新显示：直接调用歌词更新器
+                handler.post(lyricsUpdater);
+            }
+
+            @Override
+            public void onError(String error) {
+                Log.e("Mirror", "❌ 网易云歌词获取失败: " + error);
+                // 使用占位歌词作为后备
+                parseLyrics(getNcmPlaceholderLyrics());
+                // 刷新显示
+                handler.post(lyricsUpdater);
+            }
+        });
+    }
+
+    // 网易云音乐歌词占位函数：作为 API 失败时的后备
     private String getNcmPlaceholderLyrics() {
-        return "[00:00.00]网易云音乐歌词显示功能\n" +
-               "[00:03.00]这是一段示例歌词\n" +
-               "[00:06.00]🎵 当前播放的是网易云音乐\n" +
-               "[00:10.00]歌词功能开发中\n" +
-               "[00:14.00]敬请期待\n" +
-               "[00:18.00]感谢使用糯米播放器";
+        return "[00:00.00]网易云音乐\n" +
+               "[00:03.00]歌词加载中...\n" +
+               "[00:06.00]🎵 请稍候";
     }
 
     // =========================================================

--- a/shared/src/main/java/com/nuomi/shared/MyMusicService.java
+++ b/shared/src/main/java/com/nuomi/shared/MyMusicService.java
@@ -1,5 +1,6 @@
 package com.nuomi.shared;
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -14,6 +15,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.os.SystemClock;
 import android.support.v4.media.MediaBrowserCompat;
+import android.support.v4.media.MediaDescriptionCompat;
 
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import androidx.media.MediaBrowserServiceCompat;
@@ -27,7 +29,11 @@ import android.util.Pair;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -74,6 +80,18 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     private static final String MODE_NCM = "NCM";
     private static final String MODE_OTHER = "OTHER";
     private String musicMode = MODE_QQ;  // 当前模式，默认QQ音乐
+    
+    // 车机端播放器列表监听
+    private final List<android.media.session.MediaController> carMonitoredControllers = new ArrayList<>();
+    private final android.media.session.MediaController.Callback carRefreshCallback = 
+        new android.media.session.MediaController.Callback() {
+            @Override
+            public void onMetadataChanged(android.media.MediaMetadata metadata) {
+                // 播放内容变化，通知车机刷新列表
+                notifyChildrenChanged("root");
+                Log.i(TAG, "🚗 播放内容变化，刷新车机列表");
+            }
+        };
 
     // 新增：防止重复激活
     private boolean sessionActivated = false;
@@ -919,6 +937,32 @@ public class MyMusicService extends MediaBrowserServiceCompat {
                     }, 500);
                 }
             }
+            
+            @Override
+            public void onPlayFromMediaId(String mediaId, Bundle extras) {
+                // 车机端点击选择播放器
+                Log.i("Mirror", "🚗 车机端选择播放器: " + mediaId);
+                
+                // 获取应用名称
+                String appLabel = mediaId;
+                try {
+                    appLabel = getPackageManager().getApplicationLabel(
+                            getPackageManager().getApplicationInfo(mediaId, 0)).toString();
+                } catch (Exception ignore) {}
+                
+                // 保存到 SharedPreferences
+                SharedPreferences sp = getSharedPreferences("session_pref", MODE_PRIVATE);
+                sp.edit()
+                        .putString("last_pkg", mediaId)
+                        .putString("last_label", appLabel)
+                        .apply();
+                
+                Log.i("Mirror", "✅ 已选择播放器: " + appLabel + " (" + mediaId + ")");
+                
+                // 请求 Sniffer 立即重新发送 Token
+                Intent reqToken = new Intent("com.nuomi.REQUEST_TOKEN");
+                LocalBroadcastManager.getInstance(MyMusicService.this).sendBroadcast(reqToken);
+            }
         });
 
         // 同时注册 QQ / NCM 的 Token 广播
@@ -984,6 +1028,90 @@ public class MyMusicService extends MediaBrowserServiceCompat {
     @Override
     public void onLoadChildren(@NonNull String parentId,
                                @NonNull Result<List<MediaBrowserCompat.MediaItem>> result) {
-        result.sendResult(Collections.emptyList());
+        if ("root".equals(parentId)) {
+            // 返回播放器选择列表
+            List<MediaBrowserCompat.MediaItem> items = new ArrayList<>();
+            
+            try {
+                // 清理旧监听
+                for (android.media.session.MediaController c : carMonitoredControllers) {
+                    try { c.unregisterCallback(carRefreshCallback); } catch (Exception ignore) {}
+                }
+                carMonitoredControllers.clear();
+                
+                // 获取活跃的播放器列表
+                android.media.session.MediaSessionManager msm =
+                        (android.media.session.MediaSessionManager) getSystemService(Context.MEDIA_SESSION_SERVICE);
+                
+                // 使用字符串形式创建 ComponentName（因为 SessionSnifferService 在 mobile 模块）
+                ComponentName listener = new ComponentName(getPackageName(), 
+                        getPackageName() + ".SessionSnifferService");
+                java.util.List<android.media.session.MediaController> controllers = null;
+                
+                try {
+                    controllers = msm.getActiveSessions(listener);
+                } catch (SecurityException e) {
+                    // 如果没有权限，尝试使用 null
+                    try {
+                        controllers = msm.getActiveSessions(null);
+                    } catch (Exception ignore) {}
+                }
+                
+                if (controllers == null) {
+                    controllers = new ArrayList<>();
+                }
+                
+                // 去重并过滤自身包名
+                String self = getPackageName();
+                Map<String, android.media.session.MediaController> byPkg = new LinkedHashMap<>();
+                for (android.media.session.MediaController c : controllers) {
+                    String pkg = c.getPackageName();
+                    if (pkg == null || pkg.equals(self)) continue;
+                    if (!byPkg.containsKey(pkg)) {
+                        byPkg.put(pkg, c);
+                        // 注册监听，当播放内容变化时刷新车机列表
+                        c.registerCallback(carRefreshCallback);
+                        carMonitoredControllers.add(c);
+                    }
+                }
+                
+                // 构建可浏览项
+                for (android.media.session.MediaController c : byPkg.values()) {
+                    String pkg = c.getPackageName();
+                    String label = pkg;
+                    try {
+                        label = getPackageManager().getApplicationLabel(
+                                getPackageManager().getApplicationInfo(pkg, 0)).toString();
+                    } catch (Exception ignore) {}
+                    
+                    String nowPlaying = null;
+                    android.media.MediaMetadata md = c.getMetadata();
+                    if (md != null) {
+                        CharSequence t = md.getText(android.media.MediaMetadata.METADATA_KEY_TITLE);
+                        if (t != null && t.length() > 0) nowPlaying = t.toString();
+                    }
+                    
+                    String subtitle = nowPlaying != null ? "正在播放: " + nowPlaying : "点击选择此播放器";
+                    
+                    MediaDescriptionCompat desc = new MediaDescriptionCompat.Builder()
+                            .setMediaId(pkg)
+                            .setTitle(label)
+                            .setSubtitle(subtitle)
+                            .build();
+                    
+                    items.add(new MediaBrowserCompat.MediaItem(desc,
+                            MediaBrowserCompat.MediaItem.FLAG_PLAYABLE));
+                }
+                
+                Log.i("Mirror", "🚗 车机端请求播放器列表，返回 " + items.size() + " 个");
+                
+            } catch (Exception e) {
+                Log.e("Mirror", "❌ 获取播放器列表失败", e);
+            }
+            
+            result.sendResult(items);
+        } else {
+            result.sendResult(Collections.emptyList());
+        }
     }
 }

--- a/shared/src/main/java/com/nuomi/shared/NcmLyricsHelper.java
+++ b/shared/src/main/java/com/nuomi/shared/NcmLyricsHelper.java
@@ -1,0 +1,206 @@
+package com.nuomi.shared;
+
+import android.os.Handler;
+import android.os.Looper;
+import android.util.Log;
+
+import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import android.util.Base64;
+
+/**
+ * 网易云音乐歌词获取工具类
+ */
+public class NcmLyricsHelper {
+    private static final String TAG = "NcmLyricsHelper";
+    private static final String API_URL = "https://music.163.com/weapi/song/lyric";
+    
+    // 网易云音乐加密参数
+    private static final String NONCE = "0CoJUm6Qyw8W8jud";
+    private static final String PUBKEY = "010001";
+    private static final String MODULUS = "00e0b509f6259df8642dbc35662901477df22677ec152b5ff68ace615bb7b725152b3ab17a876aea8a5aa76d2e417629ec4ee341f56135fccf695280104e0312ecbda92557c93870114af6c9d05c4f7f0c3685b7a46bee255932575cce10b424d813cfe4875d3e82047b97ddef52741d546b8e289dc6935b3ece0462db0a22b8e7";
+    private static final String VI = "0102030405060708";
+    
+    private static final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private static final Handler mainHandler = new Handler(Looper.getMainLooper());
+
+    public interface LyricsCallback {
+        void onSuccess(String lyrics);
+        void onError(String error);
+    }
+
+    /**
+     * 异步获取歌词
+     * @param mediaId 网易云音乐的 MEDIA_ID
+     * @param callback 回调接口
+     */
+    public static void fetchLyrics(String mediaId, LyricsCallback callback) {
+        executor.execute(() -> {
+            try {
+                String lyrics = fetchLyricsSync(mediaId);
+                mainHandler.post(() -> callback.onSuccess(lyrics));
+            } catch (Exception e) {
+                Log.e(TAG, "获取歌词失败", e);
+                mainHandler.post(() -> callback.onError(e.getMessage()));
+            }
+        });
+    }
+
+    /**
+     * 同步获取歌词（在后台线程调用）
+     */
+    private static String fetchLyricsSync(String mediaId) throws Exception {
+        // 1. 准备请求数据
+        JSONObject rawData = new JSONObject();
+        rawData.put("id", mediaId);
+        rawData.put("os", "pc");
+        rawData.put("lv", "-1");
+        rawData.put("kv", "0");
+        rawData.put("tv", "0");
+        rawData.put("rv", "0");
+        rawData.put("yv", "0");
+        rawData.put("ytv", "0");
+        rawData.put("yrv", "0");
+        rawData.put("csrf_token", "");
+
+        // 2. 加密
+        String secretKey = createSecretKey(16);
+        String params = aesEncrypt(aesEncrypt(rawData.toString(), NONCE), secretKey);
+        String encSecKey = rsaEncrypt(secretKey);
+
+        // 3. 发送请求
+        URL url = new URL(API_URL);
+        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+        conn.setRequestMethod("POST");
+        conn.setDoOutput(true);
+        conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+        conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+        conn.setRequestProperty("Referer", "https://music.163.com");
+
+        // 4. 写入请求体
+        String postData = "params=" + urlEncode(params) + "&encSecKey=" + urlEncode(encSecKey);
+        try (OutputStream os = conn.getOutputStream()) {
+            os.write(postData.getBytes(StandardCharsets.UTF_8));
+        }
+
+        // 5. 读取响应
+        int responseCode = conn.getResponseCode();
+        if (responseCode != 200) {
+            throw new Exception("HTTP Error: " + responseCode);
+        }
+
+        StringBuilder response = new StringBuilder();
+        try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                response.append(line);
+            }
+        }
+
+        // 6. 解析 JSON 响应
+        return parseLyricsResponse(response.toString());
+    }
+
+    /**
+     * 生成随机 secretKey
+     */
+    private static String createSecretKey(int length) {
+        String chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        SecureRandom random = new SecureRandom();
+        StringBuilder result = new StringBuilder(length);
+        for (int i = 0; i < length; i++) {
+            result.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return result.toString();
+    }
+
+    /**
+     * AES 加密
+     */
+    private static String aesEncrypt(String data, String key) throws Exception {
+        SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "AES");
+        IvParameterSpec iv = new IvParameterSpec(VI.getBytes(StandardCharsets.UTF_8));
+        
+        Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey, iv);
+        
+        byte[] encrypted = cipher.doFinal(data.getBytes(StandardCharsets.UTF_8));
+        return Base64.encodeToString(encrypted, Base64.NO_WRAP);
+    }
+
+    /**
+     * RSA 加密
+     */
+    private static String rsaEncrypt(String text) {
+        // 反转字符串
+        String reversedText = new StringBuilder(text).reverse().toString();
+        
+        // 转换为 16 进制
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : reversedText.getBytes(StandardCharsets.UTF_8)) {
+            hexString.append(String.format("%02x", b));
+        }
+        
+        // BigInteger 计算
+        BigInteger bigIntText = new BigInteger(hexString.toString(), 16);
+        BigInteger bigIntPubKey = new BigInteger(PUBKEY, 16);
+        BigInteger bigIntModulus = new BigInteger(MODULUS, 16);
+        
+        BigInteger encrypted = bigIntText.modPow(bigIntPubKey, bigIntModulus);
+        String result = encrypted.toString(16);
+        
+        // 补齐到 256 位
+        while (result.length() < 256) {
+            result = "0" + result;
+        }
+        return result;
+    }
+
+    /**
+     * URL 编码
+     */
+    private static String urlEncode(String str) {
+        try {
+            return java.net.URLEncoder.encode(str, "UTF-8");
+        } catch (Exception e) {
+            return str;
+        }
+    }
+
+    /**
+     * 解析歌词响应
+     */
+    private static String parseLyricsResponse(String jsonResponse) throws Exception {
+        JSONObject json = new JSONObject(jsonResponse);
+        
+        if (json.optInt("code") != 200) {
+            throw new Exception("API返回错误: " + json.optString("msg"));
+        }
+        
+        // 获取歌词
+        JSONObject lrc = json.optJSONObject("lrc");
+        if (lrc != null) {
+            String lyric = lrc.optString("lyric", "");
+            if (!lyric.isEmpty() && !lyric.equals("null")) {
+                return lyric;
+            }
+        }
+        
+        throw new Exception("歌词数据为空");
+    }
+}

--- a/shared/src/main/java/com/nuomi/shared/NcmLyricsHelper.java
+++ b/shared/src/main/java/com/nuomi/shared/NcmLyricsHelper.java
@@ -40,7 +40,7 @@ public class NcmLyricsHelper {
     private static final Handler mainHandler = new Handler(Looper.getMainLooper());
 
     public interface LyricsCallback {
-        void onSuccess(String lyrics);
+        void onSuccess(String lyrics, String translation);
         void onError(String error);
     }
 
@@ -52,8 +52,10 @@ public class NcmLyricsHelper {
     public static void fetchLyrics(String mediaId, LyricsCallback callback) {
         executor.execute(() -> {
             try {
-                String lyrics = fetchLyricsSync(mediaId);
-                mainHandler.post(() -> callback.onSuccess(lyrics));
+                String[] result = fetchLyricsSync(mediaId);
+                String lyrics = result[0];
+                String translation = result[1];
+                mainHandler.post(() -> callback.onSuccess(lyrics, translation));
             } catch (Exception e) {
                 Log.e(TAG, "获取歌词失败", e);
                 mainHandler.post(() -> callback.onError(e.getMessage()));
@@ -63,8 +65,9 @@ public class NcmLyricsHelper {
 
     /**
      * 同步获取歌词（在后台线程调用）
+     * @return String[0]=原文歌词, String[1]=翻译歌词(可能为null)
      */
-    private static String fetchLyricsSync(String mediaId) throws Exception {
+    private static String[] fetchLyricsSync(String mediaId) throws Exception {
         // 1. 准备请求数据
         JSONObject rawData = new JSONObject();
         rawData.put("id", mediaId);
@@ -184,23 +187,39 @@ public class NcmLyricsHelper {
 
     /**
      * 解析歌词响应
+     * @return String[0]=原文, String[1]=翻译(可能为null)
      */
-    private static String parseLyricsResponse(String jsonResponse) throws Exception {
+    private static String[] parseLyricsResponse(String jsonResponse) throws Exception {
         JSONObject json = new JSONObject(jsonResponse);
         
         if (json.optInt("code") != 200) {
             throw new Exception("API返回错误: " + json.optString("msg"));
         }
         
-        // 获取歌词
+        // 获取原文歌词
+        String lyrics = null;
         JSONObject lrc = json.optJSONObject("lrc");
         if (lrc != null) {
-            String lyric = lrc.optString("lyric", "");
-            if (!lyric.isEmpty() && !lyric.equals("null")) {
-                return lyric;
+            lyrics = lrc.optString("lyric", "");
+            if (lyrics.isEmpty() || lyrics.equals("null")) {
+                lyrics = null;
             }
         }
         
-        throw new Exception("歌词数据为空");
+        // 获取翻译歌词
+        String translation = null;
+        JSONObject tlyric = json.optJSONObject("tlyric");
+        if (tlyric != null) {
+            translation = tlyric.optString("lyric", "");
+            if (translation.isEmpty() || translation.equals("null")) {
+                translation = null;
+            }
+        }
+        
+        if (lyrics == null) {
+            throw new Exception("歌词数据为空");
+        }
+        
+        return new String[]{lyrics, translation};
     }
 }

--- a/shared/src/main/res/MainActivity.java
+++ b/shared/src/main/res/MainActivity.java
@@ -152,28 +152,16 @@ public class MainActivity extends AppCompatActivity {
         activeSource = SRC_NCM.equals(savedSrc) ? SRC_NCM : SRC_QQ;
 
         // 4) 初始化两个开关
-        // 4.1 歌词模式开关
-        // 4.1 歌词模式开关（加了网易云模式的两道安全措施）
+        // 4.1 歌词模式开关（QQ 和网易云音乐都支持歌词）
         SwitchCompat switchLyrics = findViewById(R.id.switch_lyrics_mode);
 
-// 如果当前是网易云模式，则强制把歌词开关置为关闭
-        boolean initialLyrics = autoLyrics && !SRC_NCM.equals(activeSource);
-        switchLyrics.setChecked(initialLyrics);
+        // 初始状态：根据activeSource和autoLyrics设置
+        switchLyrics.setChecked(autoLyrics);
 
         switchLyrics.setOnCheckedChangeListener((buttonView, isChecked) -> {
             if (suppressLyricsToggle) return;
 
-            // 安全措施 2：网易云模式下，拦截用户尝试开启，并提示
-            if (SRC_NCM.equals(activeSource) && isChecked) {
-                suppressLyricsToggle = true;
-                switchLyrics.setChecked(false);                 // 立刻回拨
-                suppressLyricsToggle = false;
-                Toast.makeText(MainActivity.this, "网易云音乐暂不支持歌词模式", Toast.LENGTH_SHORT).show();
-                prefs.edit().putBoolean("autoLyrics", false).apply();
-                return;
-            }
-
-            // 正常路径（仅 QQ 模式允许修改）
+            // 正常路径（QQ 和网易云音乐都允许修改）
             prefs.edit().putBoolean("autoLyrics", isChecked).apply();
             if (isChecked) {
                 // 用户开启后立即激活歌词模式（由 MyMusicService 监听本地广播）
@@ -182,13 +170,10 @@ public class MainActivity extends AppCompatActivity {
             }
         });
 
-// 启动时如果偏好是 true 且当前是 QQ 模式，按原逻辑主动开启
-        if (autoLyrics && SRC_QQ.equals(activeSource)) {
+        // 启动时如果偏好是 true，主动开启歌词模式
+        if (autoLyrics) {
             Intent intent = new Intent("com.nuomi.ACTION_TOGGLE_LYRICS_MODE");
             LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
-        } else if (autoLyrics && SRC_NCM.equals(activeSource)) {
-            // 安全措施 1（启动时也生效）：如果偏好里本来是开，但当前是网易云，强制关并落盘
-            prefs.edit().putBoolean("autoLyrics", false).apply();
         }
 
 
@@ -210,16 +195,6 @@ public class MainActivity extends AppCompatActivity {
                 Toast.makeText(this,
                         isChecked ? "已切换到网易云模式" : "已切换到QQ音乐模式",
                         Toast.LENGTH_SHORT).show();
-
-                // ✅ 切到网易云：强制把歌词开关关掉，并把偏好改为 false
-                if (isChecked) {
-                    if (switchLyrics.isChecked()) {
-                        suppressLyricsToggle = true;
-                        switchLyrics.setChecked(false);
-                        suppressLyricsToggle = false;
-                    }
-                    prefs.edit().putBoolean("autoLyrics", false).apply();
-                }
 
                 // 请求对应 Sniffer 立刻重发 Token（这样无需等播放/切歌）
                 LocalBroadcastManager.getInstance(this).sendBroadcast(


### PR DESCRIPTION
你好，你做的这个app非常好用，我为了歌词显示从网易云转到qq音乐 奈何曲库还是不能比
最近休假 我也有一些coding基础 就基于1.4.0版本 fork了一下 实现了网易云音乐的歌词显示
由于网易云没有把歌词在metadata中暴露出来 我在车机端添加了一个api工具 从网易云api根据歌曲的id获取歌词 加密参数和方法参考了其他开源项目：https://github.com/jitwxs/163MusicLyrics
同时还实现了以下feature:

- 播放纯音乐时自动切换回歌名专辑模式 直到下一首歌再切换回歌词模式（如果用户在手机端开启了自动开启歌词）
- 播放日语歌曲时 同时显示翻译歌词和原文歌词 中文和英文歌词不受影响 为现在的歌词和下一句歌词
<img width="1581" height="960" alt="image" src="https://github.com/user-attachments/assets/b1714c60-fa22-4e97-9e93-bf1e68a480dd" />
- 在车机端也可以选择显示的APP了 类似AnyAutoAudio
<img width="1204" height="771" alt="image" src="https://github.com/user-attachments/assets/bff9594a-d8b4-40d4-bf91-bdc52a1599ca" />


如果pull request不方便的话 我也可以打包之后release在我自己的repo里 在readme里面加个链接就行
再次感谢！